### PR TITLE
feat: add community comments to MDX pages

### DIFF
--- a/apps/zero-app/mdx-components.tsx
+++ b/apps/zero-app/mdx-components.tsx
@@ -1,6 +1,6 @@
 import type { MDXComponents } from "mdx/types";
-
 import { cn } from "@/lib/utils";
+import { ZeroCommunityComments } from "@/root/src/components/ui/zero-community-comments";
 
 const components: MDXComponents = {
   wrapper: ({ children }) => (
@@ -8,6 +8,7 @@ const components: MDXComponents = {
       className={cn("markdown-body", "!text-zinc-300 !mx-auto max-w-3xl")}
     >
       {children}
+      <ZeroCommunityComments />
     </article>
   ),
 };


### PR DESCRIPTION
Add ZeroCommunityComments component to MDX wrapper to display
community comments at the bottom of all MDX-rendered pages.
This enables user engagement and discussion on documentation
and content pages. Also remove unnecessary blank line in
imports for consistency.