### PR TITLE
chore: bump version to 0.0.14

### DIFF
--- a/apps/zero-app/android/app/build.gradle
+++ b/apps/zero-app/android/app/build.gradle
@@ -7,8 +7,8 @@ android {
         applicationId "org.zeroopensource.zeroapp"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 13
-        versionName "0.0.13"
+        versionCode 14
+        versionName "0.0.14"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         aaptOptions {
              // Files and dirs to omit from the packaged assets dir, modified to accommodate modern web apps.

--- a/apps/zero-app/package.json
+++ b/apps/zero-app/package.json
@@ -3,7 +3,7 @@
   "displayName": "Zero",
   "productName": "Zero",
   "description": "Zero App",
-  "version": "0.0.13",
+  "version": "0.0.14",
   "license": "AGPL-3.0-or-later",
   "repository": {
     "type": "git",
@@ -37,7 +37,7 @@
     "publish:desktop": "pnpm clean && pnpm build:web && electron-forge publish",
     "sign:windows": "node src-electron/sign.mjs",
     "rebuild:windows": "cd node_modules/electron && node install.js && cd ../electron-winstaller && node script/select-7z-arch.js",
-    "rebuild:macos": "node-gyp rebuild --directory node_modules/macos-alias && node-gyp rebuild --directory node_modules/fs-xattr",
+    "rebuild:macos": "pnpm rebuild macos-alias fs-xattr",
     "sync:android": "cap sync && node src-capacitor/sync-android-version.mjs",
     "move:capacitor-outputs": "node src-capacitor/move-capacitor-outputs.mjs",
     "generate:cap:icon": "pnpx @capacitor/assets generate --iconBackgroundColor #09090b --iconBackgroundColorDark #09090b --splashBackgroundColor #09090b --splashBackgroundColorDark #09090b --assetPath /src-capacitor/assets",


### PR DESCRIPTION
Bump application version from 0.0.13 to 0.0.14 across
Android and package configuration files.

Simplify macOS rebuild script to use pnpm rebuild
instead of manual node-gyp commands for macos-alias
and fs-xattr dependencies.