### PR TITLE
chore: upgrade pnpm to 11.7.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "ultracite": "7.0.11",
     "@zeroopensource/zero-cli": "latest"
   },
-  "packageManager": "pnpm@11.5.2",
+  "packageManager": "pnpm@11.7.0",
   "engines": {
     "node": ">=18"
   }


### PR DESCRIPTION
Update the package manager version from 11.5.2 to 11.7.0
to include the latest bug fixes and improvements in the
pnpm ecosystem.