### PR TITLE
feat: configure npm workspace settings

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,2 @@
+shared-workspace-lockfile=false
+node-linker=hoisted


### PR DESCRIPTION
Configure npm to use hoisted node-linker strategy and
disable shared workspace lockfile. This ensures
dependencies are installed in a flat structure at the
root level, improving compatibility with tools that
expect node_modules in the traditional location.